### PR TITLE
Add assumeRefactoringAllowed Option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -188,6 +188,19 @@
 # d3d9.invariantPosition = True
 
 
+# Determines if the shader compiler should default to emitting all vector ALU
+# instructions with NoContraction, which limits optimizations that could
+# affect precision. This matches the expected behavior of DirectX shaders,
+# but can impact performance.
+#
+# Enabling this may improve performance in some games, but may also introduce
+# rendering issues. Please don't report bugs with the option enabled.
+#
+# Supported values: True, False
+
+# d3d11.assumeRefactoringAllowed = False
+
+
 # Forces the sample count of all textures to 1, and performs
 # the needed fixups in resolve operations and shaders.
 #

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -198,7 +198,7 @@
 #
 # Supported values: True, False
 
-# d3d11.assumeRefactoringAllowed = False
+# d3d11.refactoringAllowed = False
 
 
 # Forces the sample count of all textures to 1, and performs

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -16,6 +16,7 @@ namespace dxvk {
     this->maxTessFactor         = config.getOption<int32_t>("d3d11.maxTessFactor", 0);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d11.samplerAnisotropy", -1);
     this->invariantPosition     = config.getOption<bool>("d3d11.invariantPosition", true);
+    this->assumeRefactoringAllowed = config.getOption<bool>("d3d11.assumeRefactoringAllowed", false);
     this->floatControls         = config.getOption<bool>("d3d11.floatControls", true);
     this->disableMsaa           = config.getOption<bool>("d3d11.disableMsaa", false);
     this->deferSurfaceCreation  = config.getOption<bool>("dxgi.deferSurfaceCreation", false);

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -16,7 +16,7 @@ namespace dxvk {
     this->maxTessFactor         = config.getOption<int32_t>("d3d11.maxTessFactor", 0);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d11.samplerAnisotropy", -1);
     this->invariantPosition     = config.getOption<bool>("d3d11.invariantPosition", true);
-    this->assumeRefactoringAllowed = config.getOption<bool>("d3d11.assumeRefactoringAllowed", false);
+    this->refactoringAllowed    = config.getOption<bool>("d3d11.refactoringAllowed", false);
     this->floatControls         = config.getOption<bool>("d3d11.floatControls", true);
     this->disableMsaa           = config.getOption<bool>("d3d11.disableMsaa", false);
     this->deferSurfaceCreation  = config.getOption<bool>("dxgi.deferSurfaceCreation", false);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -69,6 +69,11 @@ namespace dxvk {
     
     /// Declare vertex positions in shaders as invariant
     bool invariantPosition;
+    
+    /// For shaders without a global RefactoringAllowed flag (mostly
+    /// shader model 4.0), emit instructions as if there was one.
+    /// Does not affect individual instructions marked as precise.
+    bool assumeRefactoringAllowed;
 
     /// Enable float control bits
     bool floatControls;

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -73,7 +73,7 @@ namespace dxvk {
     /// For shaders without a global RefactoringAllowed flag (mostly
     /// shader model 4.0), emit instructions as if there was one.
     /// Does not affect individual instructions marked as precise.
-    bool assumeRefactoringAllowed;
+    bool refactoringAllowed;
 
     /// Enable float control bits
     bool floatControls;

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -60,7 +60,7 @@ namespace dxvk {
       m_oRegs.at(i) = DxbcRegisterPointer { };
     }
     
-    if (m_moduleInfo.options.assumeRefactoringAllowed) {
+    if (m_moduleInfo.options.refactoringAllowed) {
       m_precise = false;
     }
     

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -60,6 +60,10 @@ namespace dxvk {
       m_oRegs.at(i) = DxbcRegisterPointer { };
     }
     
+    if (m_moduleInfo.options.assumeRefactoringAllowed) {
+      m_precise = false;
+    }
+    
     this->emitInit();
   }
   

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -43,7 +43,7 @@ namespace dxvk {
     forceTgsmBarriers        = options.forceTgsmBarriers;
     disableMsaa              = options.disableMsaa;
     dynamicIndexedConstantBufferAsSsbo = options.constantBufferRangeCheck;
-    assumeRefactoringAllowed = options.assumeRefactoringAllowed;
+    refactoringAllowed = options.refactoringAllowed;
 
     // Disable subgroup early discard on Nvidia because it may hurt performance
     if (adapter->matchesDriver(DxvkGpuVendor::Nvidia, VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR, 0, 0))

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -43,6 +43,7 @@ namespace dxvk {
     forceTgsmBarriers        = options.forceTgsmBarriers;
     disableMsaa              = options.disableMsaa;
     dynamicIndexedConstantBufferAsSsbo = options.constantBufferRangeCheck;
+    assumeRefactoringAllowed = options.assumeRefactoringAllowed;
 
     // Disable subgroup early discard on Nvidia because it may hurt performance
     if (adapter->matchesDriver(DxvkGpuVendor::Nvidia, VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR, 0, 0))

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -55,7 +55,7 @@ namespace dxvk {
     bool invariantPosition = false;
     
     /// Assume global flag RefactoringAllowed on all shaders
-    bool assumeRefactoringAllowed = false;
+    bool refactoringAllowed = false;
 
     /// Insert memory barriers after TGSM stoes
     bool forceTgsmBarriers = false;

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -53,6 +53,9 @@ namespace dxvk {
 
     /// Declare vertex positions as invariant
     bool invariantPosition = false;
+    
+    /// Assume global flag RefactoringAllowed on all shaders
+    bool assumeRefactoringAllowed = false;
 
     /// Insert memory barriers after TGSM stoes
     bool forceTgsmBarriers = false;


### PR DESCRIPTION
Basically adds an option to revert [this commit.](https://github.com/doitsujin/dxvk/commit/cf4ff820be2354efa30aa19a655643b908d6622d)

DXVK currently defaults to precise unless the REFACTORING_ALLOWED global flag is present and adds NoContraction to every ALU instruction in the resulting SPIR-V shader. I assume this isn't so bad performance-wise for most Vulcan drivers, but when converting to Metal, spirv-cross will [use helper functions](https://github.com/KhronosGroup/SPIRV-Cross/commit/e47a30e807990c6fe1998c9c4f291d825f043557) tagged with [[[clang:optnone]]](https://github.com/KhronosGroup/SPIRV-Cross/commit/fb3defc9ef4c22bba596c245c1cbc3a5fd3b891d) as it does for invariant float math, which is much slower.

Setting assumeRefactoringAllowed to true disables all of the above and increases fps in Dyson Sphere Program by 60-80% with no obvious graphical issues.