### PR TITLE
Fix glitch for Genshin Impact on Apple Silicon

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -761,6 +761,8 @@ namespace dxvk {
     /* Genshin Impact                          */
     { R"(\\(YuanShen|GenshinImpact)\.exe$)",{{
       { "dxgi.customDeviceDesc",            "AMD Radeon Pro 5300M"},
+      { "dxgi.customDeviceId",              "7340" },
+      { "dxgi.customVendorId",              "1002" },
       { "dxvk.enableAsync",                 "True" },
     }} },
     /* Kerbal Space Program 2                     */


### PR DESCRIPTION
Without specifying the corresponding `dxgi.customDeviceId` and `dxgi.customVendorId` of the fake GPU model (AMD Radeon Pro 5300M) on Apple Silicon Mac, there may be some graphical glitches, especially in the desert region of Genshin.

Here is what the glitch may look like:
![20230330173455](https://user-images.githubusercontent.com/44023928/228800356-faf3d71c-cfc8-4e1a-bfa8-729764602bc9.png)

So I added `dxgi.customDeviceId = 7340` and `dxgi.customVendorId = 1002` to the config in this PR. It's tested on my M1 MacBook Air with 16GB of RAM.