### PR TITLE
[util] Enable async for Jedi: Fallen Order

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -778,7 +778,6 @@ namespace dxvk {
     /* Star Wars Jedi: Fallen Order               */
     { R"(\\SwGame-Win64-Shipping\.exe$)", {{
       { "dxvk.enableAsync",                 "True" },
-      { "d3d11.floatControls",              "False" },
     }} },
   }};
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -778,6 +778,7 @@ namespace dxvk {
     /* Star Wars Jedi: Fallen Order               */
     { R"(\\SwGame-Win64-Shipping\.exe$)", {{
       { "dxvk.enableAsync",                 "True" },
+      { "d3d11.floatControls",              "False" },
     }} },
   }};
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -775,6 +775,10 @@ namespace dxvk {
     { R"(\\Overwatch\.exe$)", {{
       { "dxvk.enableAsync",                 "True" },
     }} },
+    /* Star Wars Jedi: Fallen Order               */
+    { R"(\\SwGame-Win64-Shipping\.exe$)", {{
+      { "dxvk.enableAsync",                 "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
The game also requires;
```
export MVK_CONFIG_FAST_MATH_ENABLED=MVK_CONFIG_FAST_MATH_NEVER
```
This resolves the flickering seen in-game the side affect is this lowers FPS