### PR TITLE
Add per-game env setting feature

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -992,7 +992,7 @@ namespace dxvk {
             // split input string into two separate strings
             std::string name = pair.second.substr(0, separator);
             std::string value = pair.second.substr(separator + 1);
-            Logger::info(str::format("Set Env: ", pair.second));
+            Logger::info(str::format("Set Env: ", name, "=", value));
             env::setEnvVar(name.c_str(), value.c_str());
             Logger::info(str::format("Get Env: NAS_C=", env::getEnvVar("NAS_C")));
           }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -326,6 +326,16 @@ namespace dxvk {
       { "d3d11.ignoreGraphicsBarriers",     "True" },
       { "setenv",                           "NAS_TONEMAP_C=clamp({inputColor} * float3x3( 0.2126 + 0.7874 * 1.5, 0.7152 - 0.7152 * 1.5, 0.0722 - 0.0722 * 1.5, 0.2126 - 0.2126 * 1.5, 0.7152 + 0.2848 * 1.5, 0.0722 - 0.0722 * 1.5, 0.2126 - 0.2126 * 1.5, 0.7152 - 0.7152 * 1.5, 0.0722 + 0.9278 * 1.5 ) * 2 - float3(0.28, 0.2, 0.16), 0.0, 1.0)" },     
     }} },
+    { R"(\\(CrashBandicoot4|AT-Win64-Shipping|Ghostrunner|LittleNightmares|SamuraiShodown|SoulcaliburVI|starwarsjedifallenorder|Tekken 7|TheCrew|SonsOfTheForest|SunsetOverdrive|CrabChampions|FinchGame)\.exe$)", {{
+      { "setenv",                           "MVK_CONFIG_FAST_MATH_ENABLED=0"},
+    }} },
+    { R"(\\StreetFighterV\.exe$)", {{
+      { "setenv",                           "MVK_CONFIG_FAST_MATH_ENABLED=0"},
+      { "setenv",                           "NAS_TONEMAP_C=0"},
+    }} },
+    { R"(\\(re(2|3)|DevilMayCry5)\.exe$)", {{
+      { "setenv",                           "MVK_ENABLE_EXPLICIT_LOD_WORKAROUND=0"},
+    }} },
     /* Metal Gear Solid V: Ground Zeroes          *
      * Texture quality can break at high vram     */
     { R"(\\MgsGroundZeroes\.exe$)", {{

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -985,9 +985,17 @@ namespace dxvk {
         
         Logger::info("Checking config:");
         if(pair.first == "setenv") {
-          Logger::info(str::format("Set Env: ", pair.second));
-          env::setEnvVar(pair.second.c_str());
-          Logger::info(str::format("Get Env: NAS_C=", env::getEnvVar("NAS_C")));
+          size_t separator = pair.second.find('=');
+          if (separator == std::string::npos) {
+            // handle error, separator not found
+          } else {
+            // split input string into two separate strings
+            std::string name = pair.second.substr(0, separator);
+            std::string value = pair.second.substr(separator + 1);
+            Logger::info(str::format("Set Env: ", pair.second));
+            env::setEnvVar(name.c_str(), value.c_str());
+            Logger::info(str::format("Get Env: NAS_C=", env::getEnvVar("NAS_C")));
+          }
         }
       }
       return appConfig->second;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -994,7 +994,6 @@ namespace dxvk {
             std::string value = pair.second.substr(separator + 1);
             Logger::info(str::format("Set Env: ", name, "=", value));
             env::setEnvVar(name.c_str(), value.c_str());
-            Logger::info(str::format("Get Env: NAS_C=", env::getEnvVar("NAS_C")));
           }
         }
       }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -324,6 +324,7 @@ namespace dxvk {
      * nicely with D3D11 without vendor libraries */
     { R"(\\Stray-Win64-Shipping\.exe$)", {{
       { "d3d11.ignoreGraphicsBarriers",     "True" },
+      { "setenv",                           "NAS_TONEMAP_C=clamp({inputColor} * float3x3( 0.2126 + 0.7874 * 1.5, 0.7152 - 0.7152 * 1.5, 0.0722 - 0.0722 * 1.5, 0.2126 - 0.2126 * 1.5, 0.7152 + 0.2848 * 1.5, 0.0722 - 0.0722 * 1.5, 0.2126 - 0.2126 * 1.5, 0.7152 - 0.7152 * 1.5, 0.0722 + 0.9278 * 1.5 ) * 2 - float3(0.28, 0.2, 0.16), 0.0, 1.0)" },     
     }} },
     /* Metal Gear Solid V: Ground Zeroes          *
      * Texture quality can break at high vram     */
@@ -979,9 +980,16 @@ namespace dxvk {
       // Inform the user that we loaded a default config
       Logger::info(str::format("Found built-in config:"));
 
-      for (auto& pair : appConfig->second.m_options)
+      for (auto& pair : appConfig->second.m_options) {
         Logger::info(str::format("  ", pair.first, " = ", pair.second));
-
+        
+        Logger::info("Checking config:");
+        if(pair.first == "setenv") {
+          Logger::info(str::format("Set Env: ", pair.second));
+          env::setEnvVar(pair.second.c_str());
+          Logger::info(str::format("Get Env: NAS_C=", env::getEnvVar("NAS_C")));
+        }
+      }
       return appConfig->second;
     }
 

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -13,9 +13,11 @@
 
 #include "./com/com_include.h"
 
-namespace dxvk::env {
+namespace dxvk::env
+{
 
-  std::string getEnvVar(const char* name) {
+  std::string getEnvVar(const char *name)
+  {
 #ifdef _WIN32
     std::vector<WCHAR> result;
     result.resize(MAX_PATH + 1);
@@ -25,16 +27,23 @@ namespace dxvk::env {
 
     return str::fromws(result.data());
 #else
-    const char* result = std::getenv(name);
+    const char *result = std::getenv(name);
     return result ? result : "";
 #endif
   }
 
-  void setEnvVar(const char* name, const char* value) {
+  void setEnvVar(const char *name, const char *value)
+  {
 #ifdef _WIN32
     HMODULE ntdll = GetModuleHandleA("ntdll.dll");
-    if(ntdll) {
+    if (ntdll)
+    {
       wineSetUnixEnv_proc wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_env"));
+      if (wineSetUnixEnv == NULL)
+      {
+        fprintf(stderr, "wineSetUnixEnv(): Failed to get function address\n");
+        return;
+      }
       wineSetUnixEnv(name, value);
     }
     return;
@@ -44,35 +53,36 @@ namespace dxvk::env {
 #endif
   }
 
-
-  size_t matchFileExtension(const std::string& name, const char* ext) {
+  size_t matchFileExtension(const std::string &name, const char *ext)
+  {
     auto pos = name.find_last_of('.');
 
     if (pos == std::string::npos)
       return pos;
 
     bool matches = std::accumulate(name.begin() + pos + 1, name.end(), true,
-      [&ext] (bool current, char a) {
-        if (a >= 'A' && a <= 'Z')
-          a += 'a' - 'A';
-        return current && *ext && a == *(ext++);
-      });
+                                   [&ext](bool current, char a)
+                                   {
+                                     if (a >= 'A' && a <= 'Z')
+                                       a += 'a' - 'A';
+                                     return current && *ext && a == *(ext++);
+                                   });
 
     return matches ? pos : std::string::npos;
   }
 
-
-  std::string getExeName() {
+  std::string getExeName()
+  {
     std::string fullPath = getExePath();
     auto n = fullPath.find_last_of(env::PlatformDirSlash);
-    
+
     return (n != std::string::npos)
-      ? fullPath.substr(n + 1)
-      : fullPath;
+               ? fullPath.substr(n + 1)
+               : fullPath;
   }
 
-
-  std::string getExeBaseName() {
+  std::string getExeBaseName()
+  {
     auto exeName = getExeName();
 #ifdef _WIN32
     auto extp = matchFileExtension(exeName, "exe");
@@ -84,8 +94,8 @@ namespace dxvk::env {
     return exeName;
   }
 
-
-  std::string getExePath() {
+  std::string getExePath()
+  {
 #if defined(_WIN32)
     std::vector<WCHAR> exePath;
     exePath.resize(MAX_PATH + 1);
@@ -102,16 +112,17 @@ namespace dxvk::env {
     return std::string(exePath.begin(), exePath.begin() + count);
 #endif
   }
-  
-  
-  void setThreadName(const std::string& name) {
+
+  void setThreadName(const std::string &name)
+  {
 #ifdef _WIN32
-    using SetThreadDescriptionProc = HRESULT (WINAPI *) (HANDLE, PCWSTR);
+    using SetThreadDescriptionProc = HRESULT(WINAPI *)(HANDLE, PCWSTR);
 
     static auto proc = reinterpret_cast<SetThreadDescriptionProc>(
-      ::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "SetThreadDescription"));
+        ::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "SetThreadDescription"));
 
-    if (proc != nullptr) {
+    if (proc != nullptr)
+    {
       auto wideName = std::vector<WCHAR>(name.length() + 1);
       str::tows(name.c_str(), wideName.data(), wideName.size());
       (*proc)(::GetCurrentThread(), wideName.data());
@@ -123,8 +134,8 @@ namespace dxvk::env {
 #endif
   }
 
-
-  bool createDirectory(const std::string& path) {
+  bool createDirectory(const std::string &path)
+  {
 #ifdef _WIN32
     WCHAR widePath[MAX_PATH];
     str::tows(path.c_str(), widePath);
@@ -133,5 +144,5 @@ namespace dxvk::env {
     return std::filesystem::create_directories(path);
 #endif
   }
-  
+
 }

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -30,9 +30,15 @@ namespace dxvk::env {
 #endif
   }
 
-  void setEnvVar(const char* env) {
+  void setEnvVar(const char* name, const char* value) {
+
 #ifdef _WIN32
-    putenv(env);
+    HMODULE ntdll = LoadLibrary("ntdll.dll");
+    if(ntdll) {
+      wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_envt"));
+      wineSetUnixEnv(name, value);
+      FreeLibrary(ntdll);
+    }
     return;
 #else
     putenv(env);

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstdlib>
+#include <iostream>
 #include <filesystem>
 #include <numeric>
 
@@ -26,6 +27,16 @@ namespace dxvk::env {
 #else
     const char* result = std::getenv(name);
     return result ? result : "";
+#endif
+  }
+
+  void setEnvVar(const char* env) {
+#ifdef _WIN32
+    putenv(env);
+    return;
+#else
+    putenv(env);
+    return;
 #endif
   }
 

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -32,11 +32,9 @@ namespace dxvk::env {
 
   void setEnvVar(const char* name, const char* value) {
 #ifdef _WIN32
-    wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
-    
     HMODULE ntdll = GetModuleHandleA("ntdll.dll");
     if(ntdll) {
-      wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_env"));
+      wineSetUnixEnv_proc wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_env"));
       wineSetUnixEnv(name, value);
     }
     return;

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -33,14 +33,12 @@ namespace dxvk::env {
   void setEnvVar(const char* name, const char* value) {
 #ifdef _WIN32
     wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
-    HMODULE ntdll = LoadLibrary("ntdll.dll");
+    
+    HMODULE ntdll = GetModuleHandleA("ntdll.dll");
     if(ntdll) {
       wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_env"));
       wineSetUnixEnv(name, value);
-    } else {
-      printf("couldn't call __wine_set_unix_env");
     }
-    FreeLibrary(ntdll);
     return;
 #else
     setenv(name, value);

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -31,17 +31,19 @@ namespace dxvk::env {
   }
 
   void setEnvVar(const char* name, const char* value) {
-    wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
 #ifdef _WIN32
+    wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
     HMODULE ntdll = LoadLibrary("ntdll.dll");
     if(ntdll) {
-      wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_envt"));
+      wineSetUnixEnv = reinterpret_cast<wineSetUnixEnv_proc>(GetProcAddress(ntdll, "__wine_set_unix_env"));
       wineSetUnixEnv(name, value);
-      FreeLibrary(ntdll);
+    } else {
+      printf("couldn't call __wine_set_unix_env");
     }
+    FreeLibrary(ntdll);
     return;
 #else
-    putenv(env);
+    setenv(name, value);
     return;
 #endif
   }

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -31,7 +31,7 @@ namespace dxvk::env {
   }
 
   void setEnvVar(const char* name, const char* value) {
-
+    wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
 #ifdef _WIN32
     HMODULE ntdll = LoadLibrary("ntdll.dll");
     if(ntdll) {

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -27,6 +27,13 @@ namespace dxvk::env {
    * \returns Value of the variable
    */
   std::string getEnvVar(const char* name);
+
+    /**
+   * \brief Sets environment variable
+   * 
+   * \param [in] env command as name=value
+   */
+  void setEnvVar(const char* env);
   
   /**
    * \brief Checks whether a file name has a given extension

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -28,12 +28,14 @@ namespace dxvk::env {
    */
   std::string getEnvVar(const char* name);
 
+  using wineSetUnixEnv_proc = int (STDMETHODCALLTYPE *)(const char *, const char *);
+  wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
     /**
    * \brief Sets environment variable
    * 
    * \param [in] env command as name=value
    */
-  void setEnvVar(const char* env);
+  void setEnvVar(const char* name, const char* value);
   
   /**
    * \brief Checks whether a file name has a given extension

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -28,7 +28,7 @@ namespace dxvk::env {
    */
   std::string getEnvVar(const char* name);
 
-  using wineSetUnixEnv_proc = int (STDMETHODCALLTYPE *)(const char *, const char *);
+  using wineSetUnixEnv_proc = extern void (CDECL *)(const char *, const char *);
     /**
    * \brief Sets environment variable
    * 

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -28,11 +28,13 @@ namespace dxvk::env {
    */
   std::string getEnvVar(const char* name);
 
-  using wineSetUnixEnv_proc = extern void (CDECL *)(const char *, const char *);
-    /**
+  using wineSetUnixEnv_proc = void (CDECL *)(const char *, const char *);
+  
+  /**
    * \brief Sets environment variable
-   * 
-   * \param [in] env command as name=value
+   *
+   * \param [in] env variable name 
+   * \param [in] env variable value
    */
   void setEnvVar(const char* name, const char* value);
   

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -29,7 +29,6 @@ namespace dxvk::env {
   std::string getEnvVar(const char* name);
 
   using wineSetUnixEnv_proc = int (STDMETHODCALLTYPE *)(const char *, const char *);
-  wineSetUnixEnv_proc wineSetUnixEnv = nullptr;
     /**
    * \brief Sets environment variable
    * 


### PR DESCRIPTION
This is to add a Unix-only functionality that sets an env variable from the dxvk.conf file and/or from the internal configuration (includes settings for the game 'Stray')